### PR TITLE
fix: auth error when getting images from cache

### DIFF
--- a/frontend/src/utils/momento-web.ts
+++ b/frontend/src/utils/momento-web.ts
@@ -168,7 +168,7 @@ export async function getImageMessage({
   if (resp instanceof CacheGet.Error) {
     if (resp.errorCode() === MomentoErrorCode.AUTHENTICATION_ERROR) {
       console.log(
-        "token has expired, going to refresh subscription and retry publish",
+        "token has expired, going to refresh subscription and retry getting item from cache",
       );
       clearCurrentClient();
       return await getImageMessage({ imageId });

--- a/frontend/src/utils/momento-web.ts
+++ b/frontend/src/utils/momento-web.ts
@@ -7,6 +7,7 @@ import {
   type TopicItem,
   TopicPublish,
   TopicSubscribe,
+  CacheGet,
 } from "@gomomento/sdk-web";
 import TranslationApi from "../api/translation";
 import imageCompression from "browser-image-compression";
@@ -164,6 +165,15 @@ export async function getImageMessage({
 }): Promise<string> {
   const client = await getWebCacheClient();
   const resp = await client.get(cacheName, imageId);
+  if (resp instanceof CacheGet.Error) {
+    if (resp.errorCode() === MomentoErrorCode.AUTHENTICATION_ERROR) {
+      console.log(
+        "token has expired, going to refresh subscription and retry publish",
+      );
+      clearCurrentClient();
+      return await getImageMessage({ imageId });
+    }
+  }
   return resp.value() ?? "";
 }
 


### PR DESCRIPTION
## PR Description:
Refresh the token if authentication error when getting image messages from cache


## Reference/Issue:
https://gomomento.slack.com/archives/C05T6MQLVFD/p1706636039785079