### PR TITLE
chore: add Makefile for backend pipeline build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+pipeline-build:
+	cd infrastructure && ./pipeline-build.sh

--- a/infrastructure/pipeline-build.sh
+++ b/infrastructure/pipeline-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -x
+
+pushd ../backend/lambdas
+  npm install
+  npm run build
+popd
+
+rm -f cdk.context.json
+
+npm i
+npm run build


### PR DESCRIPTION
pipeline complained about missing target `pipeline-build`