### PR TITLE
chore: add script to setup secrets for first time infrastructure setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Contains apis for the moderated chat application. There are a few apis that we a
 `GET /v1/translate/supportedLanguages` - returns the languages that the application currently supports
 `GET /v1/translate/token/<username>` - returns a short lived token that allows <username> to publish to the `chat-publish` topic
 
-In order to run these apis, there needs to be a secret stored in aws secrets manager with the path `moderated-chat/demo/secrets`. This secret should be key value pairs in the format
+In order to run these apis, there needs to be a secret stored in aws secrets manager with the path `moderated-chat/demo/secrets`. You can use the [setup-secrets.sh script](./infrastructure/setup-secrets.sh) to deploy this secret to your AWS account.
+
+This secret should be key value pairs in the format
 
 ```
 {
@@ -58,8 +60,8 @@ In order to run these apis, there needs to be a secret stored in aws secrets man
   webhookSigningSecret: "",
 }
 ```
-- the `momentoApiKey` is a token, which can be created via the [Momento Console](https://console.gomomento.com/api-keys), with super user permissions. This token will be used to vend short lived publish/subscribe api keys to the frontend
-- the `webhookSigningSecret` is the signing secret associated with the Momento Webhook. It is used to validate that requests are coming from Momento
+- the `momentoApiKey` is your Momento API key with superuser permissions. This can be created via the [Momento Console](https://console.gomomento.com/api-keys). This api key will be used to vend short lived publish/subscribe api keys to the frontend.
+- the `webhookSigningSecret` is the signing secret associated with the Momento Webhook. It is used to validate that requests are coming from Momento. This secret is updated by the custom resource lambda function when you deploy the backend infrastructure CDK stack.
 
 
 ## Frontend

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Contains apis for the moderated chat application. There are a few apis that we a
 `GET /v1/translate/supportedLanguages` - returns the languages that the application currently supports
 `GET /v1/translate/token/<username>` - returns a short lived token that allows <username> to publish to the `chat-publish` topic
 
-In order to run these apis, there needs to be a secret stored in aws secrets manager with the path `moderator/demo/secrets`. This secret should be key value pairs in the format
+In order to run these apis, there needs to be a secret stored in aws secrets manager with the path `moderated-chat/demo/secrets`. This secret should be key value pairs in the format
 
 ```
 {

--- a/infrastructure/lib/translation-api.ts
+++ b/infrastructure/lib/translation-api.ts
@@ -93,7 +93,7 @@ export class TranslationApiStack extends cdk.Stack {
             ),
         });
 
-        const secretsPath = 'moderator/demo/secrets';
+        const secretsPath = 'moderated-chat/demo/secrets';
         const v1TranslationApi = new lambda.Function(this, 'moderated-chat-translation-lambda-function', {
             functionName: `${restApiName}-api`,
             runtime: lambda.Runtime.NODEJS_20_X,

--- a/infrastructure/setup-secrets.sh
+++ b/infrastructure/setup-secrets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# This script is to setup all of the necessary secrets for the infrastructure to run. 
+# This script is really only needed when setting up the secrets for the first time.
+
+function log() {
+  local msg=$1
+  >&2 echo "$msg"
+}
+
+function usage() {
+  log "
+This script will create the AWS Secrets Manager secrets that the backend lambdas 
+expect to be present when it is run.
+Only the Momento API key secret should be passed as an environment variable to this script. 
+
+Usage:
+AWS_PROFILE=<> MOMENTO_API_KEY=<> $0
+  "
+  exit 1
+}
+
+doesCommandExist() {
+  if ! command -v $1 &> /dev/null
+  then
+      echo "$1 could not be found. Please install before running this script"
+      exit 1
+  fi
+}
+
+function createOrUpdateSecret() {
+  set +e
+  local secretName=$1
+  local secretValue=$2
+  local description=$3
+  echo "creating ${secretName} secret"
+  aws secretsmanager create-secret \
+          --secret-string "${secretValue}" \
+          --name ${secretName} \
+          --description "${description}"
+  if [ $? -eq 0 ]; then
+      echo "${secretName} secret created successfully"
+  else
+    set -e
+    echo "${secretName} secret already exists, updating it to the new value"
+    aws secretsmanager update-secret \
+          --secret-string "${secretValue}" \
+          --secret-id ${secretName}
+  fi
+  set -e
+}
+
+if [ -z "$AWS_PROFILE" ]
+then
+      echo "\$AWS_PROFILE is empty"
+      usage
+fi
+
+if [ -z "$MOMENTO_API_KEY" ]
+then
+      echo "\$MOMENTO_API_KEY is empty"
+      usage
+fi
+
+# Make sure user has aws cli installed before continuing
+doesCommandExist "aws"
+
+createOrUpdateSecret "moderator/demo/secrets" "{\"momentoApiKey\":\"${MOMENTO_API_KEY}\", \"momentoSigningSecret\":\"placeholder-will-be-replaced-during-cdk-setup\"}"

--- a/infrastructure/setup-secrets.sh
+++ b/infrastructure/setup-secrets.sh
@@ -68,4 +68,4 @@ fi
 # Make sure user has aws cli installed before continuing
 doesCommandExist "aws"
 
-createOrUpdateSecret "moderator/demo/secrets" "{\"momentoApiKey\":\"${MOMENTO_API_KEY}\", \"momentoSigningSecret\":\"placeholder-will-be-replaced-during-cdk-setup\"}"
+createOrUpdateSecret "moderated-chat/demo/secrets" "{\"momentoApiKey\":\"${MOMENTO_API_KEY}\", \"momentoSigningSecret\":\"placeholder-will-be-replaced-during-cdk-deploy\"}" "Momento API key and webhook signing secrets used for the multi-langauge moderated chat demo"


### PR DESCRIPTION
Adds a first-time-setup script for creating the AWS Secrets Manager secrets expected by the moderated chat infrastructure.